### PR TITLE
feat(app): add '~' path alias and fix DnD checkbox bug

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,6 +25,46 @@ export default [
       // React Hooks
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'warn',
+      // Import style
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['../../*'],
+              message: 'Используйте алиас ~ вместо глубоких относительных импортов.',
+            },
+            {
+              group: ['../../../*'],
+              message: 'Используйте алиас ~ вместо глубоких относительных импортов.',
+            },
+            {
+              group: ['../../../../*'],
+              message: 'Используйте алиас ~ вместо глубоких относительных импортов.',
+            },
+            {
+              group: ['../../../../../*'],
+              message: 'Используйте алиас ~ вместо глубоких относительных импортов.',
+            },
+            {
+              group: ['./../../*'],
+              message: 'Используйте алиас ~ вместо глубоких относительных импортов.',
+            },
+            {
+              group: ['./../../../*'],
+              message: 'Используйте алиас ~ вместо глубоких относительных импортов.',
+            },
+            {
+              group: ['./../../../../*'],
+              message: 'Используйте алиас ~ вместо глубоких относительных импортов.',
+            },
+            {
+              group: ['./../../../../../*'],
+              message: 'Используйте алиас ~ вместо глубоких относительных импортов.',
+            },
+          ],
+        },
+      ],
     },
   },
   // Node окружение для конфигов/скриптов
@@ -33,6 +73,19 @@ export default [
     languageOptions: {
       globals: { ...globals.node },
       sourceType: 'commonjs',
+    },
+  },
+  {
+    files: ['scripts/**/*.mjs', '*.mjs'],
+    languageOptions: {
+      globals: { ...globals.node },
+      sourceType: 'module',
+    },
+    rules: {
+      // Разрешаем escape-последовательности в регэкспах утилитных скриптов
+      'no-useless-escape': 'off',
+      // В node-скриптах доступны process, __dirname и т.п.
+      'no-undef': 'off',
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prepare": "husky",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "aliasize-imports": "node scripts/aliasize-imports.mjs",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
     "typecheck": "tsc -p tsconfig.json --noEmit",
@@ -57,6 +58,7 @@
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [
+      "node scripts/aliasize-imports.mjs",
       "eslint --fix",
       "prettier --write"
     ],

--- a/scripts/aliasize-imports.mjs
+++ b/scripts/aliasize-imports.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+
+const SRC_ROOT = path.resolve(process.cwd(), 'src')
+
+function* walk(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+  for (const e of entries) {
+    if (e.name === 'node_modules' || e.name === 'dist') continue
+    const full = path.join(dir, e.name)
+    if (e.isDirectory()) {
+      yield* walk(full)
+    } else if (/\.(tsx?|jsx?)$/.test(e.name)) {
+      yield full
+    }
+  }
+}
+
+function toAlias(fromFile, source) {
+  if (!source.startsWith('../')) return null
+  const abs = path.resolve(path.dirname(fromFile), source)
+  if (!abs.startsWith(SRC_ROOT)) return null
+  let relToSrc = path.relative(SRC_ROOT, abs).replace(/\\/g, '/')
+  if (!relToSrc) return null
+  return `~/${relToSrc}`
+}
+
+const importRe = /(import|export)\s+[^'";]*?from\s+['"]([^'\"]+)['"];?/g
+const sideEffectImportRe = /^\s*import\s+['"]([^'\"]+)['"];?/gm
+
+function processFile(file) {
+  if (
+    !file.endsWith('.ts') &&
+    !file.endsWith('.tsx') &&
+    !file.endsWith('.js') &&
+    !file.endsWith('.jsx')
+  )
+    return 0
+  const abs = path.isAbsolute(file) ? file : path.resolve(process.cwd(), file)
+  if (!abs.startsWith(SRC_ROOT)) return 0
+  if (!fs.existsSync(abs)) return 0
+  const src = fs.readFileSync(abs, 'utf8')
+  let out = src
+  out = out.replace(importRe, (m, kw, spec) => {
+    const alias = toAlias(abs, spec)
+    if (!alias) return m
+    return m.replace(spec, alias)
+  })
+  out = out.replace(sideEffectImportRe, (m, spec) => {
+    const alias = toAlias(abs, spec)
+    if (!alias) return m
+    return m.replace(spec, alias)
+  })
+  if (out !== src) {
+    fs.writeFileSync(abs, out, 'utf8')
+    console.log(`Updated: ${path.relative(process.cwd(), abs)}`)
+    return 1
+  }
+  return 0
+}
+
+const args = process.argv.slice(2)
+let changed = 0
+if (args.length) {
+  for (const f of args) changed += processFile(f)
+} else {
+  for (const file of walk(SRC_ROOT)) {
+    changed += processFile(file)
+  }
+}
+
+console.log(changed ? `Done. ${changed} file(s) updated.` : 'No changes needed.')

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { HomePage } from '../pages/home/ui/HomePage'
+import { HomePage } from '~/pages/home/ui/HomePage'
 
 function App() {
   return <HomePage />

--- a/src/entities/todo/lib/storage.ts
+++ b/src/entities/todo/lib/storage.ts
@@ -1,4 +1,4 @@
-import type { Todo } from '../model/types'
+import type { Todo } from '~/entities/todo/model/types'
 
 const STORAGE_KEY = 'todos'
 

--- a/src/entities/todo/model/useTodos.ts
+++ b/src/entities/todo/model/useTodos.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import type { Todo } from './types'
-import { loadTodos, saveTodos } from '../lib/storage'
+import type { Todo } from '~/entities/todo/model/types'
+import { loadTodos, saveTodos } from '~/entities/todo/lib/storage'
 
 export function useTodos() {
   const [todos, setTodos] = useState<Todo[]>(() => loadTodos())

--- a/src/features/reorder-todos/ui/SortableList.tsx
+++ b/src/features/reorder-todos/ui/SortableList.tsx
@@ -9,8 +9,8 @@ import {
 } from '@dnd-kit/core'
 import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import type { Todo } from '../../../entities/todo/model/types'
-import { TodoItem } from '../../todo-item/ui/TodoItem'
+import type { Todo } from '~/entities/todo/model/types'
+import { TodoItem } from '~/features/todo-item/ui/TodoItem'
 
 type Props = {
   items: Todo[]
@@ -38,10 +38,24 @@ function SortableTodo({
       ref={setNodeRef}
       style={style}
       className={`bg-white ${isDragging ? 'bg-indigo-50 shadow-sm' : ''}`}
-      {...attributes}
-      {...listeners}
     >
-      <TodoItem todo={todo} onToggle={onToggle} onRemove={onRemove} />
+      <TodoItem
+        todo={todo}
+        onToggle={onToggle}
+        onRemove={onRemove}
+        dragHandle={
+          <button
+            type="button"
+            aria-label="Переместить задачу"
+            title="Переместить"
+            className="mr-1 cursor-grab touch-none select-none text-gray-300 hover:text-gray-500"
+            {...attributes}
+            {...listeners}
+          >
+            ⋮⋮
+          </button>
+        }
+      />
     </li>
   )
 }

--- a/src/features/todo-item/ui/TodoItem.tsx
+++ b/src/features/todo-item/ui/TodoItem.tsx
@@ -1,15 +1,18 @@
-import type { Todo } from '../../../entities/todo/model/types'
+import type { ReactNode } from 'react'
+import type { Todo } from '~/entities/todo/model/types'
 
 type Props = {
   todo: Todo
   onToggle: (id: string) => void
   onRemove: (id: string) => void
+  dragHandle?: ReactNode
 }
 
-export function TodoItem({ todo, onToggle, onRemove }: Props) {
+export function TodoItem({ todo, onToggle, onRemove, dragHandle }: Props) {
   const base = todo.completed ? 'text-gray-500 line-through' : 'text-gray-900'
   return (
-    <li className="flex items-center gap-3 p-3 select-none">
+    <div className="flex items-center gap-3 p-3 select-none">
+      {dragHandle}
       <input
         id={`todo-${todo.id}`}
         type="checkbox"
@@ -28,6 +31,6 @@ export function TodoItem({ todo, onToggle, onRemove }: Props) {
       >
         ✕
       </button>
-    </li>
+    </div>
   )
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import App from './app/App'
+import App from '~/app/App'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/src/pages/home/ui/HomePage.tsx
+++ b/src/pages/home/ui/HomePage.tsx
@@ -1,4 +1,4 @@
-import { TodosWidget } from '../../../widgets/todos/ui/TodosWidget'
+import { TodosWidget } from '~/widgets/todos/ui/TodosWidget'
 
 export function HomePage() {
   return (

--- a/src/widgets/todos/ui/TodosWidget.tsx
+++ b/src/widgets/todos/ui/TodosWidget.tsx
@@ -1,6 +1,6 @@
-import { AddTodoForm } from '../../../features/add-todo/ui/AddTodoForm'
-import { SortableList } from '../../../features/reorder-todos/ui/SortableList'
-import { useTodos } from '../../../entities/todo/model/useTodos'
+import { AddTodoForm } from '~/features/add-todo/ui/AddTodoForm'
+import { SortableList } from '~/features/reorder-todos/ui/SortableList'
+import { useTodos } from '~/entities/todo/model/useTodos'
 
 export function TodosWidget() {
   const { active, completed, add, toggle, remove, reorderInGroup } = useTodos()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,11 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["src/*"]
+    }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,12 +1,18 @@
-import { defineConfig } from 'vitest/config';
-import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
 // https://vitejs.dev/config/
 export default defineConfig({
     // Для GitHub Pages: BASE_URL=/<repo>/ во время сборки
     base: process.env.BASE_URL || '/',
     plugins: [react()],
+    resolve: {
+        alias: {
+            '~': fileURLToPath(new URL('./src', import.meta.url)),
+        },
+    },
     test: {
         environment: 'jsdom',
         globals: true,
     },
-});
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitest/config'
+import { fileURLToPath, URL } from 'node:url'
 import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
@@ -6,6 +7,11 @@ export default defineConfig({
   // Для GitHub Pages: BASE_URL=/<repo>/ во время сборки
   base: process.env.BASE_URL || '/',
   plugins: [react()],
+  resolve: {
+    alias: {
+      '~': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
- Add Vite/TS alias '~' -> 'src' and refactor imports
- Add ESLint rule to forbid deep relative imports
- Add aliasize-imports script + lint-staged hook
- Fix: use drag handle to prevent checkbox toggle during drag
- Adjust TodoItem markup to avoid nested <li>